### PR TITLE
Add simplified weather server and improve documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,19 +11,32 @@ This is a collection of MCP (Model Context Protocol) servers providing various t
 
 ## Development Commands
 
+### Environment Setup
+**Create virtual environment:** `python -m venv venv`
+
+**Activate virtual environment:** 
+- Linux/Mac: `source venv/bin/activate`
+- Windows: `venv\Scripts\activate`
+
 **Install global dependencies:** `pip install -r requirements.txt` (add `--break-system-packages` flag if required by system)
 
 **Install server-specific dependencies:** `pip install -r servers/[server-name]/requirements.txt`
 
+### Server Operations
 **Run weather server:** `python servers/weather/weather_server.py`
 
 **Test weather server startup:** `timeout 5s python servers/weather/weather_server.py` (kills after 5s to test initialization)
 
 **Run any server:** `python servers/[server-name]/[server-name]_server.py`
 
-**Debug server:** Set `LOG_LEVEL=DEBUG` in environment or config files for verbose logging
+**Debug server:** Set `LOG_LEVEL=DEBUG` in environment (use `.env` file based on `.env.example`) or config files for verbose logging
 
-**Kill existing servers:** Always kill existing servers before starting new ones during development to avoid port conflicts
+**Kill existing servers:** Always kill existing servers before starting new ones during development to avoid port conflicts - use `Ctrl+C` or `pkill -f python` if needed
+
+### Validation
+**Test server tools:** After starting a server, test its tools through Claude Desktop or VS Code to ensure proper functionality
+
+**Validate API responses:** Check that external API calls (NWS, OpenStreetMap) are working correctly
 
 ## Architecture
 
@@ -67,10 +80,18 @@ mcp-concept/
 ### Configuration
 
 **IDE Integration:** Configuration templates in `config/` directory:
-- `claude_desktop_config.json`: For Claude Desktop integration (update absolute path to point to `servers/weather/weather_server.py`)
-- `vscode_mcp_config.json`: For VS Code/Cursor integration (uses `${workspaceFolder}/servers/weather/weather_server.py`)
+- `claude_desktop_config.json`: For Claude Desktop integration (MUST update absolute path `/absolute/path/to/mcp-concept/servers/weather/weather_server.py` to actual installation path)
+- `vscode_mcp_config.json`: For VS Code/Cursor integration (uses relative path `${workspaceFolder}/servers/weather/weather_server.py`)
 
-**Environment:** Optional `.env` file (no API keys required), LOG_LEVEL configurable
+**Environment Configuration:** 
+- Copy `.env.example` to `.env` if needed (no API keys required for weather server)
+- Configure `LOG_LEVEL` (INFO, DEBUG, WARNING, ERROR) in `.env` file or config files
+- Environment variables take precedence over config file settings
+
+**Path Requirements:**
+- Claude Desktop configs require absolute paths
+- VS Code/Cursor configs can use workspace-relative paths with `${workspaceFolder}`
+- Always verify paths exist before testing integration
 
 ## Key Patterns
 
@@ -84,19 +105,28 @@ mcp-concept/
 
 ### Adding New Servers
 1. Create new directory under `servers/[server-name]/`
-2. Follow established patterns from weather server
-3. Use FastMCP framework with `@mcp.tool()` decorators
+2. Follow established patterns from weather server (`servers/weather/weather_server.py` as template)
+3. Use FastMCP framework with `@mcp.tool()` decorators for tool registration
 4. Create server-specific `requirements.txt`, `README.md`, and `__init__.py`
-5. Update config files to include new server
+5. Update both config files in `config/` directory to include new server
 6. Keep individual servers focused on specific capabilities
 
-### Important Notes
-- Servers must be restarted after code changes for testing
+### Development Workflow
+- **Code Changes:** Servers must be restarted after any code changes for testing
+- **Concurrent Development:** Can run multiple servers simultaneously, but ensure different ports/processes
+- **Server Lifecycle:** Always kill existing servers (`Ctrl+C`) before starting new ones during development
+- **Testing Cycle:** Start server → Test in Claude Desktop/VS Code → Stop server → Make changes → Repeat
+
+### Code Standards
 - Keep individual server files under 300 lines when possible (weather server currently ~259 lines)
-- Each server should focus on a specific set of related capabilities
-- Always kill existing servers before starting new ones during development
+- Each server should focus on a specific set of related capabilities  
 - Follow existing error handling and async patterns from weather server
-- Include comprehensive documentation for each server
 - MCP servers use stdio transport and require proper FastMCP initialization with `mcp.run()`
 - All external API calls should be async with proper timeout handling (30s default)
+- Return user-friendly error messages, not raw exceptions
+- Use consistent logging with proper log levels
+
+### Configuration Management
 - Configuration files in `config/` directory need absolute paths updated for new servers
+- Test configurations before committing by actually running the integration
+- Document any environment variables or special setup requirements

--- a/config/claude_desktop_config.json
+++ b/config/claude_desktop_config.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "nws-weather": {
       "command": "python",
-      "args": ["/absolute/path/to/mcp-concept/servers/weather/weather_server.py"],
+      "args": ["/home/tkhongsap/my-github/mcp-concept/servers/weather/weather_server.py"],
       "env": {
         "LOG_LEVEL": "INFO"
       }

--- a/servers/weather/simple_weather_server.py
+++ b/servers/weather/simple_weather_server.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Simple Weather MCP Server
+A simplified weather server using the National Weather Service API
+"""
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+# Setup
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("simple-weather")
+mcp = FastMCP("simple-weather")
+
+# Constants
+NWS_BASE = "https://api.weather.gov"
+GEOCODING_API = "https://nominatim.openstreetmap.org/search"
+USER_AGENT = "simple-weather-mcp/1.0"
+
+
+async def get_coordinates(location: str) -> Optional[Tuple[float, float]]:
+    """Convert location name to lat/lon coordinates."""
+    # If already coordinates, parse them
+    if ',' in location and location.replace('-', '').replace('.', '').replace(',', '').isdigit():
+        try:
+            lat, lon = map(float, location.split(','))
+            return lat, lon
+        except ValueError:
+            pass
+    
+    # Otherwise, geocode the location
+    params = {
+        "q": location,
+        "format": "json",
+        "limit": 1,
+        "countrycodes": "us"
+    }
+    
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(
+                GEOCODING_API, 
+                params=params, 
+                headers={"User-Agent": USER_AGENT},
+                timeout=10.0
+            )
+            response.raise_for_status()
+            data = response.json()
+            
+            if data:
+                return float(data[0]["lat"]), float(data[0]["lon"])
+                
+        except Exception as e:
+            logger.error(f"Geocoding error: {e}")
+    
+    return None
+
+
+async def fetch_weather_data(lat: float, lon: float) -> Optional[Dict[str, Any]]:
+    """Fetch weather data from NWS API."""
+    headers = {"User-Agent": USER_AGENT}
+    
+    async with httpx.AsyncClient() as client:
+        try:
+            # Get point data first
+            point_response = await client.get(
+                f"{NWS_BASE}/points/{lat},{lon}",
+                headers=headers,
+                timeout=30.0
+            )
+            point_response.raise_for_status()
+            point_data = point_response.json()
+            
+            # Get forecast URL
+            forecast_url = point_data["properties"]["forecast"]
+            
+            # Get forecast data
+            forecast_response = await client.get(forecast_url, headers=headers, timeout=30.0)
+            forecast_response.raise_for_status()
+            forecast_data = forecast_response.json()
+            
+            return {
+                "location": point_data["properties"],
+                "forecast": forecast_data["properties"]["periods"]
+            }
+            
+        except Exception as e:
+            logger.error(f"Weather API error: {e}")
+            return None
+
+
+@mcp.tool()
+async def get_weather(location: str) -> str:
+    """
+    Get weather forecast for a US location.
+    
+    Args:
+        location: City name and state (e.g., "Seattle, WA") or coordinates (e.g., "47.6,-122.3")
+    
+    Returns:
+        Weather forecast as formatted text
+    """
+    # Get coordinates
+    coords = await get_coordinates(location)
+    if not coords:
+        return f"❌ Could not find location: {location}"
+    
+    lat, lon = coords
+    
+    # Get weather data
+    weather_data = await fetch_weather_data(lat, lon)
+    if not weather_data:
+        return f"❌ Could not get weather data for {location}"
+    
+    # Format response
+    location_info = weather_data["location"]
+    forecast_periods = weather_data["forecast"]
+    
+    # Get location name
+    rel_location = location_info.get("relativeLocation", {}).get("properties", {})
+    city = rel_location.get("city", "Unknown")
+    state = rel_location.get("state", "Unknown")
+    
+    result = f"🌤️ **Weather for {city}, {state}**\n"
+    result += f"📍 {lat:.2f}, {lon:.2f}\n\n"
+    
+    # Show current and next few periods
+    for i, period in enumerate(forecast_periods[:6]):
+        name = period.get("name", "Unknown")
+        temp = period.get("temperature", "?")
+        unit = period.get("temperatureUnit", "F")
+        forecast = period.get("shortForecast", "No data")
+        
+        if i == 0:
+            result += f"**Current: {name}**\n"
+        else:
+            result += f"**{name}**\n"
+            
+        result += f"🌡️ {temp}°{unit} - {forecast}\n\n"
+    
+    return result.strip()
+
+
+if __name__ == "__main__":
+    logger.info("Starting Simple Weather MCP Server...")
+    mcp.run() 

--- a/servers/weather/weather_server.py
+++ b/servers/weather/weather_server.py
@@ -30,7 +30,7 @@ async def make_nws_request(url: str) -> dict[str, Any] | None:
         "User-Agent": USER_AGENT,
         "Accept": "application/geo+json"
     }
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(follow_redirects=True) as client:
         try:
             response = await client.get(url, headers=headers, timeout=30.0)
             response.raise_for_status()


### PR DESCRIPTION
## Summary
- Added `simple_weather_server.py` as a minimal MCP server implementation example (~150 lines)
- Enhanced CLAUDE.md documentation with better organization and clearer development guidance
- Fixed httpx redirect handling in main weather server and updated config paths

## Test plan
- [ ] Verify simple weather server starts correctly: `python servers/weather/simple_weather_server.py`
- [ ] Test weather functionality with both servers
- [ ] Confirm Claude Desktop integration works with updated config path
- [ ] Review enhanced documentation for clarity and completeness

🤖 Generated with [Claude Code](https://claude.ai/code)